### PR TITLE
Add initial Go boilerplate

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - go run ./cmd/tasksamurai

--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"tasksamurai/internal"
+)
+
+func main() {
+	fmt.Println("tasksamurai version", internal.Version)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module tasksamurai
+
+go 1.23.8

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,3 @@
+package internal
+
+const Version = "v0.1.0"


### PR DESCRIPTION
## Summary
- initialize Go module and `go.mod`
- add simple `cmd/tasksamurai` entrypoint printing version
- define version constant under `internal`
- provide basic Taskfile for running the program

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go run ./cmd/tasksamurai`

------
https://chatgpt.com/codex/tasks/task_e_685471bed4cc83219710b16bf8400f1f