### PR TITLE
Add run task and compile binary by default

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,6 +3,9 @@ version: '3'
 tasks:
   default:
     cmds:
+      - go build -o tasksamurai ./cmd/tasksamurai
+  run:
+    cmds:
       - go run ./cmd/tasksamurai
   test:
     cmds:


### PR DESCRIPTION
## Summary
- build `tasksamurai` in the default task
- provide a `run` task that executes `main.go` directly

## Testing
- `go test ./...` *(fails: exec: "task": executable file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685478f73f2c8321a4fa2c3b697e1b83