### PR TITLE
Implement task helpers and refine due date style

### DIFF
--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -85,8 +85,9 @@ func formatDue(s string) string {
 
 	days := int(time.Until(ts).Hours() / 24)
 	val := fmt.Sprintf("%dd", days)
+	style := lipgloss.NewStyle()
 	if days < 0 {
-		val = lipgloss.NewStyle().Background(lipgloss.Color("1")).Render(val)
+		style = style.Background(lipgloss.Color("1"))
 	}
-	return val
+	return style.Render(val)
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os/exec"
+	"strconv"
 )
 
 // Task represents a taskwarrior task as returned by `task export`.
@@ -70,4 +71,73 @@ func Export() ([]Task, error) {
 		return nil, err
 	}
 	return tasks, nil
+}
+
+func run(args ...string) error {
+	cmd := exec.Command("task", args...)
+	return cmd.Run()
+}
+
+// SetStatus changes the status of the task with the given id.
+func SetStatus(id int, status string) error {
+	return run(strconv.Itoa(id), "modify", "status:"+status)
+}
+
+// SetPriority changes the priority of the task with the given id.
+func SetPriority(id int, priority string) error {
+	return run(strconv.Itoa(id), "modify", "priority:"+priority)
+}
+
+// AddTags adds tags to the task with the given id.
+func AddTags(id int, tags []string) error {
+	args := []string{strconv.Itoa(id), "modify"}
+	for _, t := range tags {
+		if len(t) > 0 && t[0] != '+' {
+			t = "+" + t
+		}
+		args = append(args, t)
+	}
+	return run(args...)
+}
+
+// RemoveTags removes tags from the task with the given id.
+func RemoveTags(id int, tags []string) error {
+	args := []string{strconv.Itoa(id), "modify"}
+	for _, t := range tags {
+		if len(t) > 0 && t[0] != '-' {
+			t = "-" + t
+		}
+		args = append(args, t)
+	}
+	return run(args...)
+}
+
+// SetRecurrence sets the recurrence for the task with the given id.
+func SetRecurrence(id int, rec string) error {
+	return run(strconv.Itoa(id), "modify", "recur:"+rec)
+}
+
+// SetDueDate sets the due date for the task with the given id.
+func SetDueDate(id int, due string) error {
+	return run(strconv.Itoa(id), "modify", "due:"+due)
+}
+
+// SetDescription changes the description of the task with the given id.
+func SetDescription(id int, desc string) error {
+	return run(strconv.Itoa(id), "modify", "description:"+desc)
+}
+
+// Annotate adds an annotation to the task with the given id.
+func Annotate(id int, text string) error {
+	return run(strconv.Itoa(id), "annotate", text)
+}
+
+// Denotate removes an annotation from the task with the given id.
+func Denotate(id int, annoID int) error {
+	return run(strconv.Itoa(id), "denotate", strconv.Itoa(annoID))
+}
+
+// Edit opens the task in an editor for manual modification.
+func Edit(id int) error {
+	return run(strconv.Itoa(id), "edit")
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -54,3 +54,70 @@ func TestAddAndExport(t *testing.T) {
 		t.Errorf("missing task 'hello universe'")
 	}
 }
+
+func TestModifyHelpers(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.Setenv("TASKDATA", tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("TASKRC", "/dev/null"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	if err := Add("hello", nil); err != nil {
+		t.Fatalf("add task: %v", err)
+	}
+
+	if err := SetPriority(1, "H"); err != nil {
+		t.Fatalf("set priority: %v", err)
+	}
+	if err := AddTags(1, []string{"foo"}); err != nil {
+		t.Fatalf("add tags: %v", err)
+	}
+	if err := SetDescription(1, "hello there"); err != nil {
+		t.Fatalf("set description: %v", err)
+	}
+	if err := Annotate(1, "note"); err != nil {
+		t.Fatalf("annotate: %v", err)
+	}
+
+	tasks, err := Export()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	t1 := tasks[0]
+	if t1.Priority != "H" {
+		t.Errorf("priority not set: %v", t1.Priority)
+	}
+	found := false
+	for _, tag := range t1.Tags {
+		if tag == "foo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("tag not added")
+	}
+	if t1.Description != "hello there" {
+		t.Errorf("description not set: %v", t1.Description)
+	}
+	annFound := false
+	for _, a := range t1.Annotations {
+		if a.Description == "note" {
+			annFound = true
+			break
+		}
+	}
+	if !annFound {
+		t.Errorf("annotation not added")
+	}
+}


### PR DESCRIPTION
## Summary
- add helpers for manipulating task state via the Taskwarrior CLI
- test new helpers using a temporary Taskwarrior database
- make the due date cell red only when overdue

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68547ebe198883219224aa75fe234acd