### PR TITLE
Add cell navigation, editor hotkey, stats and filter

### DIFF
--- a/internal/task/stats.go
+++ b/internal/task/stats.go
@@ -1,0 +1,40 @@
+package task
+
+import "time"
+
+// TotalTasks returns the number of tasks provided.
+func TotalTasks(tasks []Task) int {
+	return len(tasks)
+}
+
+// InProgressTasks returns the number of tasks that have been started and are not completed.
+func InProgressTasks(tasks []Task) int {
+	count := 0
+	for _, t := range tasks {
+		if t.Status == "completed" {
+			continue
+		}
+		if t.Start != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// DueTasks returns the number of tasks with a due date that is not in the future.
+func DueTasks(tasks []Task, now time.Time) int {
+	count := 0
+	for _, t := range tasks {
+		if t.Status == "completed" || t.Due == "" {
+			continue
+		}
+		ts, err := time.Parse("20060102T150405Z", t.Due)
+		if err != nil {
+			continue
+		}
+		if !ts.After(now) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/task/stats_test.go
+++ b/internal/task/stats_test.go
@@ -1,0 +1,28 @@
+package task
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStats(t *testing.T) {
+	now := time.Now()
+	tasks := []Task{
+		{Description: "t1"},
+		{Description: "t2", Start: "20240101T000000Z"},
+		{Description: "t3", Due: now.Add(-time.Hour).Format("20060102T150405Z")},
+		{Description: "t4", Start: "20240101T000000Z", Due: now.Add(-time.Hour).Format("20060102T150405Z")},
+	}
+
+	if TotalTasks(tasks) != 4 {
+		t.Errorf("total tasks wrong: %d", TotalTasks(tasks))
+	}
+
+	if InProgressTasks(tasks) != 2 {
+		t.Errorf("in progress wrong: %d", InProgressTasks(tasks))
+	}
+
+	if DueTasks(tasks, now) != 2 {
+		t.Errorf("due tasks wrong: %d", DueTasks(tasks, now))
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -46,8 +46,12 @@ func Add(description string, tags []string) error {
 
 // Export retrieves all tasks using `task export rc.json.array=off` and parses
 // the JSON output into a slice of Task structs.
-func Export() ([]Task, error) {
-	cmd := exec.Command("task", "export", "rc.json.array=off")
+// Export retrieves tasks using `task <filter> export rc.json.array=off` and parses
+// the JSON output into a slice of Task structs. Optional filter arguments are
+// passed directly to the `task` command before `export`.
+func Export(filters ...string) ([]Task, error) {
+	args := append(filters, "export", "rc.json.array=off")
+	cmd := exec.Command("task", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -1,19 +1,43 @@
 package ui
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
 	atable "tasksamurai/internal/atable"
+	"tasksamurai/internal/task"
 )
 
 // Model wraps a Bubble Tea table.Model to display tasks.
 type Model struct {
 	tbl      atable.Model
 	showHelp bool
+
+	filter string
+	tasks  []task.Task
+
+	total      int
+	inProgress int
+	due        int
 }
 
 // New creates a new UI model with the provided rows.
-func New(rows []atable.Row) Model {
+func New(filter string) (Model, error) {
+	m := Model{filter: filter}
+
+	if err := m.reload(); err != nil {
+		return Model{}, err
+	}
+
+	return m, nil
+}
+
+func newTable(rows []atable.Row) atable.Model {
 	cols := []atable.Column{
 		{Title: "ID", Width: 4},
 		{Title: "Task", Width: 30},
@@ -36,7 +60,36 @@ func New(rows []atable.Row) Model {
 	styles.Selected = styles.Selected.Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57"))
 	styles.Cell = styles.Cell.Padding(0, 1)
 	t.SetStyles(styles)
-	return Model{tbl: t}
+	return t
+}
+
+func (m *Model) reload() error {
+	tasks, err := task.Export(strings.Fields(m.filter)...)
+	if err != nil {
+		return err
+	}
+
+	var rows []atable.Row
+	var filtered []task.Task
+	for _, tsk := range tasks {
+		if tsk.Status == "completed" {
+			continue
+		}
+		filtered = append(filtered, tsk)
+		rows = append(rows, taskToRow(tsk))
+	}
+
+	m.tasks = filtered
+	m.total = task.TotalTasks(filtered)
+	m.inProgress = task.InProgressTasks(filtered)
+	m.due = task.DueTasks(filtered, time.Now())
+
+	if m.tbl.Columns() == nil {
+		m.tbl = newTable(rows)
+	} else {
+		m.tbl.SetRows(rows)
+	}
+	return nil
 }
 
 // Init implements tea.Model.
@@ -60,6 +113,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, tea.Quit
+		case "E":
+			if row := m.tbl.SelectedRow(); row != nil {
+				id, err := strconv.Atoi(row[0])
+				if err == nil {
+					_ = task.Edit(id)
+					m.reload()
+				}
+			}
 		}
 	}
 
@@ -81,5 +142,64 @@ func (m Model) View() string {
 			"?: help", // show help toggle line
 		)
 	}
-	return m.tbl.View()
+	return lipgloss.JoinVertical(lipgloss.Left,
+		m.tbl.View(),
+		m.statusLine(),
+	)
+}
+
+func (m Model) statusLine() string {
+	return fmt.Sprintf("Total:%d InProgress:%d Due:%d", m.total, m.inProgress, m.due)
+}
+
+func taskToRow(t task.Task) atable.Row {
+	active := ""
+	if t.Start != "" {
+		active = "yes"
+	}
+
+	age := ""
+	if ts, err := time.Parse("20060102T150405Z", t.Entry); err == nil {
+		days := int(time.Since(ts).Hours() / 24)
+		age = fmt.Sprintf("%dd", days)
+	}
+
+	tags := strings.Join(t.Tags, ",")
+	urg := fmt.Sprintf("%.1f", t.Urgency)
+
+	var anns []string
+	for _, a := range t.Annotations {
+		anns = append(anns, a.Description)
+	}
+
+	return atable.Row{
+		strconv.Itoa(t.ID),
+		t.Description,
+		active,
+		age,
+		t.Priority,
+		tags,
+		t.Recur,
+		formatDue(t.Due),
+		urg,
+		strings.Join(anns, "; "),
+	}
+}
+
+func formatDue(s string) string {
+	if s == "" {
+		return ""
+	}
+	ts, err := time.Parse("20060102T150405Z", s)
+	if err != nil {
+		return s
+	}
+
+	days := int(time.Until(ts).Hours() / 24)
+	val := fmt.Sprintf("%dd", days)
+	style := lipgloss.NewStyle()
+	if days < 0 {
+		style = style.Background(lipgloss.Color("1"))
+	}
+	return style.Render(val)
 }


### PR DESCRIPTION
## Summary
- allow cell-level selection in table with hjkl/arrow keys
- add `E` hotkey to edit tasks and reload table
- show stats line with totals, in-progress and due counts
- support filtering tasks via `--filter` flag
- implement stat helpers and tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854fe1c7bc4832190e4de43c9e71b58