### PR TITLE
Enhance task table view

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -64,7 +64,8 @@ func newTable(rows []atable.Row) atable.Model {
 }
 
 func (m *Model) reload() error {
-	tasks, err := task.Export(strings.Fields(m.filter)...)
+	filters := append(strings.Fields(m.filter), "status:pending")
+	tasks, err := task.Export(filters...)
 	if err != nil {
 		return err
 	}
@@ -177,7 +178,7 @@ func taskToRow(t task.Task) atable.Row {
 		t.Description,
 		active,
 		age,
-		t.Priority,
+		formatPriority(t.Priority),
 		tags,
 		t.Recur,
 		formatDue(t.Due),
@@ -202,4 +203,19 @@ func formatDue(s string) string {
 		style = style.Background(lipgloss.Color("1"))
 	}
 	return style.Render(val)
+}
+
+func formatPriority(p string) string {
+	style := lipgloss.NewStyle()
+	switch p {
+	case "L":
+		style = style.Foreground(lipgloss.Color("10"))
+	case "M":
+		style = style.Foreground(lipgloss.Color("12"))
+	case "H":
+		style = style.Foreground(lipgloss.Color("9"))
+	default:
+		return p
+	}
+	return style.Render(p)
 }


### PR DESCRIPTION
## Summary
- filter only pending tasks when loading from TaskWarrior
- colorize priority values in the task table

## Testing
- `go test ./...` *(fails: exec: "task": executable file not found in $PATH)*

------
https://chatgpt.com/codex/tasks/task_e_685504f9e70c8321a6d83b95e59b5968