### PR TITLE
Align status line color with selected cell

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -162,7 +162,11 @@ func (m Model) View() string {
 }
 
 func (m Model) statusLine() string {
-	return fmt.Sprintf("Total:%d InProgress:%d Due:%d", m.total, m.inProgress, m.due)
+	status := fmt.Sprintf("Total:%d InProgress:%d Due:%d", m.total, m.inProgress, m.due)
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Render(status)
 }
 
 func taskToRow(t task.Task) atable.Row {


### PR DESCRIPTION
## Summary
- match status line color to the highlighted cell

## Testing
- `go test ./...` *(fails: `task` executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_685505df730883219b060841b2e43c89