### PR TITLE
Fix editor command and cell alignment

### DIFF
--- a/internal/atable/table.go
+++ b/internal/atable/table.go
@@ -465,12 +465,12 @@ func (m *Model) renderRow(r int) string {
 		if m.cols[i].Width <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		cellStyle := m.styles.Cell
+		style := m.styles.Cell
 		if r == m.cursor && i == m.colCursor {
-			cellStyle = m.styles.Selected
+			style = m.styles.Selected
 		}
-		renderedCell := cellStyle.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
+		style = style.Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
+		renderedCell := style.Render(ansi.Truncate(value, m.cols[i].Width, "…"))
 		s = append(s, renderedCell)
 	}
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"strconv"
 )
@@ -146,7 +147,11 @@ func Denotate(id int, annoID int) error {
 // The caller is responsible for running the command, typically via
 // tea.ExecProcess so that the terminal state is properly managed.
 func EditCmd(id int) *exec.Cmd {
-	return exec.Command("task", strconv.Itoa(id), "edit")
+	cmd := exec.Command("task", strconv.Itoa(id), "edit")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
 }
 
 // Edit opens the task in an editor for manual modification.


### PR DESCRIPTION
## Summary
- ensure `task edit` runs interactively by wiring stdin/stdout/stderr
- keep table columns aligned when navigating between cells

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855058b22d88321ba5b27675f638d3e