### PR TITLE
Add debug log and fix editing bug

### DIFF
--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"tasksamurai/internal/task"
 	"tasksamurai/internal/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,7 +13,13 @@ import (
 
 func main() {
 	filter := flag.String("filter", "", "task filter expression")
+	debugLog := flag.String("debug-log", "", "path to debug log file")
 	flag.Parse()
+
+	if err := task.SetDebugLog(*debugLog); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to enable debug log:", err)
+		os.Exit(1)
+	}
 
 	m, err := ui.New(*filter)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.8.0
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -130,13 +132,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "e", "E":
 			if row := m.tbl.SelectedRow(); row != nil {
-				if id, err := strconv.Atoi(row[0]); err == nil {
+				idStr := ansi.Strip(row[0])
+				if id, err := strconv.Atoi(idStr); err == nil {
 					return m, editCmd(id)
 				}
 			}
 		case "s":
 			if row := m.tbl.SelectedRow(); row != nil {
-				if id, err := strconv.Atoi(row[0]); err == nil {
+				idStr := ansi.Strip(row[0])
+				if id, err := strconv.Atoi(idStr); err == nil {
 					started := false
 					for _, tsk := range m.tasks {
 						if tsk.ID == id {


### PR DESCRIPTION
## Summary
- allow enabling debug logging via `--debug-log` flag
- log task commands executed when debug log enabled
- fix editing of started tasks by stripping ANSI codes

## Testing
- `go test ./...` *(fails: executable `task` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68557bb38260832194763bb5d0994d98