### PR TITLE
Improve screen clearing on TUI start

### DIFF
--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -27,7 +27,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(&m)
+	// Clear the screen before starting the TUI to avoid leaving any
+	// previous command line artefacts behind.
+	fmt.Print("\033[H\033[2J")
+
+	p := tea.NewProgram(&m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "error running ui:", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- clear the terminal before starting the TUI
- use Bubble Tea's alt screen to avoid leftover artefacts

## Testing
- `go test ./...` *(fails: task command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557d2f0c34832197652bb788c07b6a