### PR TITLE
Hide table headers and show selected column

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -64,6 +64,7 @@ func newTable(rows []atable.Row) atable.Model {
 		atable.WithColumns(cols),
 		atable.WithRows(rows),
 		atable.WithFocused(true),
+		atable.WithShowHeaders(false),
 	)
 	styles := atable.DefaultStyles()
 	styles.Header = styles.Header.Foreground(lipgloss.Color("205"))
@@ -185,7 +186,12 @@ func (m Model) View() string {
 }
 
 func (m Model) statusLine() string {
-	status := fmt.Sprintf("Total:%d InProgress:%d Due:%d", m.total, m.inProgress, m.due)
+	header := ""
+	cols := m.tbl.Columns()
+	if idx := m.tbl.ColumnCursor(); idx >= 0 && idx < len(cols) {
+		header = cols[idx].Title
+	}
+	status := fmt.Sprintf("%s Total:%d InProgress:%d Due:%d", header, m.total, m.inProgress, m.due)
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("229")).
 		Background(lipgloss.Color("57")).


### PR DESCRIPTION
## Summary
- add `showHeaders` flag and new `WithShowHeaders` option to table model
- render table without headers when flag is false
- show header text for the currently selected column in status line

## Testing
- `go test ./...` *(fails: exec: "task" not found)*
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557ee2dce8832199ee3f1037a7eaeb