### PR TITLE
Add annotation replacement hotkey

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -175,6 +175,29 @@ func Denotate(id int, annoID int) error {
 	return run(strconv.Itoa(id), "denotate", strconv.Itoa(annoID))
 }
 
+// ReplaceAnnotations removes all existing annotations from the task with the
+// given id and sets a single annotation with the provided text. If text is
+// empty, all annotations are simply removed.
+func ReplaceAnnotations(id int, text string) error {
+	tasks, err := Export(strconv.Itoa(id))
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("task %d not found", id)
+	}
+	anns := tasks[0].Annotations
+	for i := len(anns); i >= 1; i-- {
+		if err := Denotate(id, i); err != nil {
+			return err
+		}
+	}
+	if text == "" {
+		return nil
+	}
+	return Annotate(id, text)
+}
+
 // Edit opens the task in an editor for manual modification.
 // EditCmd returns an exec.Cmd that edits the task with the given id.
 // The caller is responsible for running the command, typically via

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -62,3 +62,68 @@ func TestAnnotateHotkey(t *testing.T) {
 		t.Fatalf("annotation not recorded: %q", data)
 	}
 }
+
+func TestReplaceAnnotationHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	annoFile := filepath.Join(tmp, "anno.txt")
+	logFile := filepath.Join(tmp, "log.txt")
+
+	script := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0,\"annotations\":[{\"entry\":\"\",\"description\":\"old\"}]}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$@\" >> " + logFile + "\n" +
+		"if [ \"$1\" = \"1\" ] && [ \"$2\" = \"annotate\" ]; then\n" +
+		"  echo \"$3\" > " + annoFile + "\n" +
+		"  exit 0\n" +
+		"fi\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New("")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m = mv.(Model)
+	for _, r := range "new" {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = mv.(Model)
+	}
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(annoFile)
+	if err != nil {
+		t.Fatalf("read ann: %v", err)
+	}
+
+	if strings.TrimSpace(string(data)) != "new" {
+		t.Fatalf("annotation not recorded: %q", data)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	if !strings.Contains(string(logData), "denotate") {
+		t.Fatalf("denotate not called: %s", logData)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ReplaceAnnotations` to task helpers
- allow `A` hotkey to replace existing annotations
- document the new hotkey in the help view
- test replacing annotations via the new hotkey

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557fc4c8988321a94fa6b65100180b