### PR TITLE
Improve tag handling UI

### DIFF
--- a/internal/atable/table.go
+++ b/internal/atable/table.go
@@ -306,6 +306,9 @@ func (m *Model) UpdateViewport() {
 	m.end = clamp(m.cursor+m.viewport.Height, m.cursor, len(m.rows))
 	for i := m.start; i < m.end; i++ {
 		renderedRows = append(renderedRows, m.renderRow(i))
+		if i < m.end-1 {
+			renderedRows = append(renderedRows, "")
+		}
 	}
 
 	m.viewport.SetContent(

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -150,6 +150,23 @@ func RemoveTags(id int, tags []string) error {
 	return run(args...)
 }
 
+// SetTags replaces all tags on the task with the provided set.
+func SetTags(id int, tags []string) error {
+	clean := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimPrefix(t, "+")
+		t = strings.TrimPrefix(t, "-")
+		if t != "" {
+			clean = append(clean, t)
+		}
+	}
+	arg := "tags:"
+	if len(clean) > 0 {
+		arg += strings.Join(clean, ",")
+	}
+	return run(strconv.Itoa(id), "modify", arg)
+}
+
 // SetRecurrence sets the recurrence for the task with the given id.
 func SetRecurrence(id int, rec string) error {
 	return run(strconv.Itoa(id), "modify", "recur:"+rec)

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -128,3 +128,39 @@ func TestModifyHelpers(t *testing.T) {
 		t.Errorf("annotation not added")
 	}
 }
+
+func TestSetTags(t *testing.T) {
+	if _, err := exec.LookPath("task"); err != nil {
+		t.Skip("task command not available")
+	}
+	tmp := t.TempDir()
+	if err := os.Setenv("TASKDATA", tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("TASKRC", "/dev/null"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	if err := Add("hello", []string{"foo", "bar"}); err != nil {
+		t.Fatalf("add task: %v", err)
+	}
+
+	if err := SetTags(1, []string{"baz"}); err != nil {
+		t.Fatalf("set tags: %v", err)
+	}
+
+	tasks, err := Export()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if len(tasks[0].Tags) != 1 || tasks[0].Tags[0] != "baz" {
+		t.Errorf("tags not replaced: %+v", tasks[0].Tags)
+	}
+}

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -62,3 +62,55 @@ func TestAnnotateHotkey(t *testing.T) {
 		t.Fatalf("annotation not recorded: %q", data)
 	}
 }
+
+func TestTagHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	logFile := filepath.Join(tmp, "cmd.log")
+
+	script := "#!/bin/sh\n" +
+		"echo \"$@\" >> " + logFile + "\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0,\"annotations\":[],\"tags\":[\"bar\"]}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New("")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = mv.(Model)
+	for _, r := range []rune("+foo -bar") {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = mv.(Model)
+	}
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "modify +foo") || !strings.Contains(out, "modify -bar") {
+		t.Fatalf("commands not executed: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- adjust table row spacing for readability
- show tags with leading plus and space separation
- add SetTags function for replacing tags
- support editing tags via `t`/`T` hotkeys
- document tag hotkeys in help
- test new tag editing behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685581324d7083218b3ca078fd35d7fa