### PR TITLE
Add tag editing and improved table spacing

### DIFF
--- a/internal/atable/table.go
+++ b/internal/atable/table.go
@@ -490,7 +490,8 @@ func (m *Model) renderRow(r int) string {
 		s = append(s, renderedCell)
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
+	row := lipgloss.JoinHorizontal(lipgloss.Top, s...)
+	return lipgloss.NewStyle().MarginBottom(1).Render(row)
 }
 
 func clamp(v, low, high int) int {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -150,6 +150,27 @@ func RemoveTags(id int, tags []string) error {
 	return run(args...)
 }
 
+// ReplaceTags removes all existing tags and sets the provided list.
+func ReplaceTags(id int, tags []string) error {
+	tasks, err := Export(strconv.Itoa(id))
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("task %d not found", id)
+	}
+	existing := tasks[0].Tags
+	if len(existing) > 0 {
+		if err := RemoveTags(id, existing); err != nil {
+			return err
+		}
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	return AddTags(id, tags)
+}
+
 // SetRecurrence sets the recurrence for the task with the given id.
 func SetRecurrence(id int, rec string) error {
 	return run(strconv.Itoa(id), "modify", "recur:"+rec)

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -127,3 +127,105 @@ func TestReplaceAnnotationHotkey(t *testing.T) {
 		t.Fatalf("denotate not called: %s", logData)
 	}
 }
+
+func TestTagHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	logFile := filepath.Join(tmp, "log.txt")
+
+	script := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0,\"tags\":[\"old\"],\"annotations\":[]}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$@\" >> " + logFile + "\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New("")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = mv.(Model)
+	for _, r := range "+foo -old" {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = mv.(Model)
+	}
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "+foo") || !strings.Contains(out, "-old") {
+		t.Fatalf("tag commands not recorded: %s", out)
+	}
+}
+
+func TestReplaceTagsHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	logFile := filepath.Join(tmp, "log.txt")
+
+	script := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0,\"tags\":[\"old\"],\"annotations\":[]}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$@\" >> " + logFile + "\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New("")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'T'}})
+	m = mv.(Model)
+	for _, r := range "foo bar" {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = mv.(Model)
+	}
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "-old") || !strings.Contains(out, "+foo") {
+		t.Fatalf("replace tag commands not recorded: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- display rows with extra spacing for readability
- show tags with + prefix and space-separated
- support `t` and `T` hotkeys to modify or replace tags
- document new hotkeys in help menu
- add tests for tag modifications

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68559bd6bd148321b3947e3f935c1ac5