### PR TITLE
Improve status bar width

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -271,6 +271,7 @@ func (m Model) statusLine() string {
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("229")).
 		Background(lipgloss.Color("57")).
+		Width(m.tbl.Width()).
 		Render(status)
 }
 
@@ -283,6 +284,7 @@ func (m Model) topStatusLine() string {
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("229")).
 		Background(lipgloss.Color("57")).
+		Width(m.tbl.Width()).
 		Render(header)
 }
 


### PR DESCRIPTION
## Summary
- widen status bars so they span the full terminal width

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68559fbf3bdc8321aba44b47f9bee1ad