### PR TITLE
Add random due date hotkey

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,10 @@ import (
 	atable "tasksamurai/internal/atable"
 	"tasksamurai/internal/task"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // Model wraps a Bubble Tea table.Model to display tasks.
 type Model struct {
@@ -236,6 +241,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 			}
+		case "r":
+			if row := m.tbl.SelectedRow(); row != nil {
+				idStr := ansi.Strip(row[0])
+				if id, err := strconv.Atoi(idStr); err == nil {
+					days := rand.Intn(31) + 7
+					due := time.Now().AddDate(0, 0, days).Format("2006-01-02")
+					task.SetDueDate(id, due)
+					m.reload()
+				}
+			}
 		case "a":
 			if row := m.tbl.SelectedRow(); row != nil {
 				idStr := ansi.Strip(row[0])
@@ -281,6 +296,7 @@ func (m Model) View() string {
 			"s: toggle start/stop",
 			"D: mark task done",
 			"d: set due date",
+			"r: random due date",
 			"a: annotate task",
 			"A: replace annotations",
 			"q: quit",

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -221,5 +222,60 @@ func TestDueDateHotkey(t *testing.T) {
 
 	if strings.TrimSpace(string(data)) != "1 modify due:2024-12-31" {
 		t.Fatalf("due not set: %q", data)
+	}
+}
+
+func TestRandomDueDateHotkey(t *testing.T) {
+	tmp := t.TempDir()
+	taskPath := filepath.Join(tmp, "task")
+	dueFile := filepath.Join(tmp, "due.txt")
+
+	script := "#!/bin/sh\n" +
+		"if echo \"$@\" | grep -q export; then\n" +
+		"  echo '{\"id\":1,\"uuid\":\"x\",\"description\":\"d\",\"status\":\"pending\",\"entry\":\"\",\"priority\":\"\",\"urgency\":0}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$@\" > " + dueFile + "\n"
+
+	if err := os.WriteFile(taskPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	os.Setenv("TASKDATA", tmp)
+	os.Setenv("TASKRC", "/dev/null")
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	m, err := New("")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = mv.(Model)
+
+	data, err := os.ReadFile(dueFile)
+	if err != nil {
+		t.Fatalf("read due: %v", err)
+	}
+
+	parts := strings.Split(strings.TrimSpace(string(data)), " ")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected command: %q", data)
+	}
+	dueStr := strings.TrimPrefix(parts[2], "due:")
+	dueTime, err := time.Parse("2006-01-02", dueStr)
+	if err != nil {
+		t.Fatalf("parse due: %v", err)
+	}
+	days := int(time.Until(dueTime).Hours() / 24)
+	if days < 7 || days > 37 {
+		t.Fatalf("due date out of range: %d", days)
 	}
 }


### PR DESCRIPTION
## Summary
- randomize due date via new `r` hotkey
- document the new hotkey in the help view
- test for the random due date hotkey

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855a08141d8832196fdbab20ca95cf5