### PR TITLE
Adjust sort order to prioritize priority

### DIFF
--- a/internal/task/sort_test.go
+++ b/internal/task/sort_test.go
@@ -21,7 +21,7 @@ func TestSortTasks(t *testing.T) {
 	for _, tsk := range tasks {
 		ids = append(ids, tsk.ID)
 	}
-	want := []int{1, 5, 6, 4, 2, 3}
+	want := []int{1, 5, 6, 2, 4, 3}
 	if !reflect.DeepEqual(ids, want) {
 		t.Fatalf("unexpected order: %v", ids)
 	}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -235,7 +235,7 @@ func Edit(id int) error {
 	return EditCmd(id).Run()
 }
 
-// SortTasks orders tasks by due date, priority, tag names and id.
+// SortTasks orders tasks by priority, due date, tag names and id.
 // Tasks without a due date are placed after tasks with a due date.
 func SortTasks(tasks []Task) {
 	joinTags := func(tags []string) string {
@@ -274,6 +274,11 @@ func SortTasks(tasks []Task) {
 	sort.Slice(tasks, func(i, j int) bool {
 		ti, tj := tasks[i], tasks[j]
 
+		pi, pj := priVal(ti.Priority), priVal(tj.Priority)
+		if pi != pj {
+			return pi > pj
+		}
+
 		di, iok := parseDue(ti.Due)
 		dj, jok := parseDue(tj.Due)
 		if iok && !jok {
@@ -284,11 +289,6 @@ func SortTasks(tasks []Task) {
 		}
 		if iok && jok && !di.Equal(dj) {
 			return di.Before(dj)
-		}
-
-		pi, pj := priVal(ti.Priority), priVal(tj.Priority)
-		if pi != pj {
-			return pi > pj
 		}
 
 		tgI, tgJ := joinTags(ti.Tags), joinTags(tj.Tags)


### PR DESCRIPTION
## Summary
- modify `SortTasks` to sort by priority first, then due date
- update tests for new order

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855a153f1248321a2fc29c80b3cb687