### PR TITLE
Add priority management hotkeys

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -138,6 +138,11 @@ func SetPriority(id int, priority string) error {
 	return run(strconv.Itoa(id), "modify", "priority:"+priority)
 }
 
+// DeletePriority removes the priority from the task with the given id.
+func DeletePriority(id int) error {
+	return run(strconv.Itoa(id), "modify", "priority:")
+}
+
 // AddTags adds tags to the task with the given id.
 func AddTags(id int, tags []string) error {
 	args := []string{strconv.Itoa(id), "modify"}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -128,3 +128,41 @@ func TestModifyHelpers(t *testing.T) {
 		t.Errorf("annotation not added")
 	}
 }
+
+func TestDeletePriority(t *testing.T) {
+	if _, err := exec.LookPath("task"); err != nil {
+		t.Skip("task command not available")
+	}
+	tmp := t.TempDir()
+	if err := os.Setenv("TASKDATA", tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("TASKRC", "/dev/null"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Unsetenv("TASKDATA")
+		os.Unsetenv("TASKRC")
+	})
+
+	if err := Add("hello", nil); err != nil {
+		t.Fatalf("add task: %v", err)
+	}
+	if err := SetPriority(1, "H"); err != nil {
+		t.Fatalf("set priority: %v", err)
+	}
+	if err := DeletePriority(1); err != nil {
+		t.Fatalf("delete priority: %v", err)
+	}
+
+	tasks, err := Export()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Priority != "" {
+		t.Errorf("priority not cleared: %v", tasks[0].Priority)
+	}
+}

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -314,7 +314,11 @@ func TestSetPriorityHotkey(t *testing.T) {
 
 	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
 	m = mv.(Model)
-	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}})
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = mv.(Model)
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = mv.(Model)
+	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = mv.(Model)
 	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = mv.(Model)


### PR DESCRIPTION
## Summary
- allow clearing priority with `DeletePriority`
- prompt for priority with `p` and clear with `P`
- show priority helpers in help screen
- test priority hotkeys and deletion

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855a2acebe48321a03e675b39de6e41