### PR TITLE
Pass CLI args to task

### DIFF
--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 func main() {
-	filter := flag.String("filter", "", "task filter expression")
 	debugLog := flag.String("debug-log", "", "path to debug log file")
 	flag.Parse()
 
@@ -21,7 +20,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	m, err := ui.New(*filter)
+	m, err := ui.New(flag.Args())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "failed to load tasks:", err)
 		os.Exit(1)

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -40,7 +40,7 @@ func TestAnnotateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestReplaceAnnotationHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestDoneHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestDueDateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestRandomDueDateHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
## Summary
- pass all CLI arguments directly to `task export`
- adjust `Model` to accept a slice of filter args
- update UI tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855a34d91908321b3db4e8e7ab0a0fb