### PR TITLE
Fix undo of completed tasks

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -113,6 +113,11 @@ func SetStatus(id int, status string) error {
 	return run(strconv.Itoa(id), "modify", "status:"+status)
 }
 
+// SetStatusUUID changes the status of the task with the given UUID.
+func SetStatusUUID(uuid, status string) error {
+	return run(uuid, "modify", "status:"+status)
+}
+
 // Start begins the task with the given id.
 func Start(id int) error {
 	return run(strconv.Itoa(id), "start")

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -39,7 +39,7 @@ type Model struct {
 	filters []string
 	tasks   []task.Task
 
-	undoStack []int
+	undoStack []string
 
 	total      int
 	inProgress int
@@ -224,15 +224,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				idStr := ansi.Strip(row[0])
 				if id, err := strconv.Atoi(idStr); err == nil {
 					task.Done(id)
-					m.undoStack = append(m.undoStack, id)
+					for _, tsk := range m.tasks {
+						if tsk.ID == id {
+							m.undoStack = append(m.undoStack, tsk.UUID)
+							break
+						}
+					}
 					m.reload()
 				}
 			}
 		case "U":
 			if n := len(m.undoStack); n > 0 {
-				id := m.undoStack[n-1]
+				uuid := m.undoStack[n-1]
 				m.undoStack = m.undoStack[:n-1]
-				task.SetStatus(id, "pending")
+				task.SetStatusUUID(uuid, "pending")
 				m.reload()
 			}
 		case "d":

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -202,7 +202,7 @@ func TestUndoHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestUndoHotkey(t *testing.T) {
 	if lines[0] != "1 done" {
 		t.Fatalf("done not called: %q", lines[0])
 	}
-	if lines[1] != "1 modify status:pending" {
+	if lines[1] != "x modify status:pending" {
 		t.Fatalf("undo not called: %q", lines[1])
 	}
 }


### PR DESCRIPTION
## Summary
- store UUIDs in the undo stack
- add `SetStatusUUID` helper
- undo completed tasks using the stored UUID
- update tests accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855a6d1abe48321a16276283de279aa