### PR TITLE
Fix fireworks exit by ignoring leftover key

### DIFF
--- a/internal/ui/fireworks.go
+++ b/internal/ui/fireworks.go
@@ -9,10 +9,11 @@ import (
 )
 
 type fwModel struct {
-	width  int
-	height int
-	start  time.Time
-	fws    []firework
+	width          int
+	height         int
+	start          time.Time
+	fws            []firework
+	ignoreFirstKey bool
 }
 
 type firework struct {
@@ -66,6 +67,10 @@ func (m fwModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tick()
 	case tea.KeyMsg:
+		if !m.ignoreFirstKey {
+			m.ignoreFirstKey = true
+			return m, nil
+		}
 		return m, tea.Quit
 	}
 	return m, nil

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -202,7 +202,7 @@ func TestUndoHotkey(t *testing.T) {
 		os.Unsetenv("TASKRC")
 	})
 
-	m, err := New("")
+	m, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
## Summary
- ignore the first key after starting the fireworks animation
- fix broken tests that passed a string to `ui.New`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855a77e354083218c85aa7e08246cf2