### PR TITLE
Add vi-style navigation for priority selection

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -199,9 +199,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case tea.KeyEsc:
 				m.prioritySelecting = false
 				return m, nil
-			case tea.KeyLeft:
+			}
+			switch msg.String() {
+			case "h", "left":
 				m.priorityIndex = (m.priorityIndex + len(priorityOptions) - 1) % len(priorityOptions)
-			case tea.KeyRight:
+			case "l", "right":
 				m.priorityIndex = (m.priorityIndex + 1) % len(priorityOptions)
 			}
 			return m, nil


### PR DESCRIPTION
## Summary
- allow `h`/`l` keys for navigating priority options

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855a84aef748321bc4e6aa8acdf9ae0