### PR TITLE
Fix fireworks not appearing on quit

### DIFF
--- a/internal/ui/fireworks.go
+++ b/internal/ui/fireworks.go
@@ -29,6 +29,9 @@ func tick() tea.Cmd {
 
 func (m fwModel) Init() tea.Cmd {
 	m.start = time.Now()
+	// Ignore the first key in case the exit key from the previous program
+	// is still buffered when the fireworks start.
+	m.ignoreFirstKey = true
 	return tick()
 }
 


### PR DESCRIPTION
## Summary
- ignore leftover exit key when starting fireworks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855a8ad871c8321af882beb8356bb92