### PR TITLE
Prioritize started tasks in sorting

### DIFF
--- a/internal/task/sort_test.go
+++ b/internal/task/sort_test.go
@@ -26,3 +26,23 @@ func TestSortTasks(t *testing.T) {
 		t.Fatalf("unexpected order: %v", ids)
 	}
 }
+
+func TestSortTasksStartedFirst(t *testing.T) {
+	tasks := []Task{
+		{ID: 1, Priority: "M", Start: "20240101T000000Z"},
+		{ID: 2, Priority: "H"},
+		{ID: 3, Priority: "H", Start: "20240102T000000Z"},
+		{ID: 4, Priority: "L"},
+	}
+
+	SortTasks(tasks)
+
+	var ids []int
+	for _, tsk := range tasks {
+		ids = append(ids, tsk.ID)
+	}
+	want := []int{3, 1, 2, 4}
+	if !reflect.DeepEqual(ids, want) {
+		t.Fatalf("unexpected order: %v", ids)
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -240,8 +240,9 @@ func Edit(id int) error {
 	return EditCmd(id).Run()
 }
 
-// SortTasks orders tasks by priority, due date, tag names and id.
-// Tasks without a due date are placed after tasks with a due date.
+// SortTasks orders tasks by start status, priority, due date, tag names and id.
+// Started tasks are always placed before non-started ones. Tasks without a due
+// date are placed after tasks with a due date.
 func SortTasks(tasks []Task) {
 	joinTags := func(tags []string) string {
 		if len(tags) == 0 {
@@ -278,6 +279,12 @@ func SortTasks(tasks []Task) {
 
 	sort.Slice(tasks, func(i, j int) bool {
 		ti, tj := tasks[i], tasks[j]
+
+		startedI := ti.Start != "" && ti.Status != "completed"
+		startedJ := tj.Start != "" && tj.Status != "completed"
+		if startedI != startedJ {
+			return startedI
+		}
 
 		pi, pj := priVal(ti.Priority), priVal(tj.Priority)
 		if pi != pj {


### PR DESCRIPTION
## Summary
- put started tasks at top when sorting
- update tests for new started-first sorting behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855a91c01288321bad4891f1c1ad8e9