### PR TITLE
Update cell color defaults

### DIFF
--- a/internal/atable/table.go
+++ b/internal/atable/table.go
@@ -128,7 +128,10 @@ func DefaultStyles() Styles {
 	return Styles{
 		Selected: lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212")),
 		Header:   lipgloss.NewStyle().Bold(true).Padding(0, 1),
-		Cell:     lipgloss.NewStyle().Padding(0, 1),
+		Cell: lipgloss.NewStyle().
+			Padding(0, 1).
+			Foreground(lipgloss.Color("226")).
+			Background(lipgloss.Color("21")),
 	}
 }
 


### PR DESCRIPTION
## Summary
- change default table cell color to yellow text on blue background

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855aa61c7548321bc49c4dbd28e6a4d