### PR TITLE
Add ESC alias for q and search exit

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -272,12 +272,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "?":
 			m.showHelp = true
 			return m, nil
-		case "q":
+		case "q", "esc":
 			if m.showHelp {
 				m.showHelp = false
 				return m, nil
 			}
-			return m, tea.Quit
+			if m.searchRegex != nil {
+				m.searchRegex = nil
+				m.searchMatches = nil
+				m.searchIndex = 0
+				m.reload()
+				return m, nil
+			}
+			if msg.String() == "q" {
+				return m, tea.Quit
+			}
+			return m, nil
 		case "e", "E":
 			if row := m.tbl.SelectedRow(); row != nil {
 				idStr := ansi.Strip(row[0])


### PR DESCRIPTION
## Summary
- add ESC as alias for `q` except for quitting
- allow `q` and ESC to exit search matches
- test new ESC behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855b7cd167c8321a1974f2cb59e9679