### PR TITLE
Add search hotkeys to help menu

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -427,6 +427,7 @@ func (m Model) View() string {
 			"a: annotate task",
 			"A: replace annotations",
 			"p: set priority",
+			"/, ?: search",
 			"q: quit",
 			"h: help", // show help toggle line
 		)


### PR DESCRIPTION
## Summary
- show `/` and `?` as search shortcuts in help menu

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855b9c0e4388321bdbff07d52c590db