### PR TITLE
Add ESC hotkey alias for exiting help and search

### DIFF
--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -470,7 +470,7 @@ func TestEscClosesHelp(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m = mv.(Model)
 	if !m.showHelp {
 		t.Fatalf("help not shown")


### PR DESCRIPTION
## Summary
- adjust help hotkey tests for `h`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855ba4cbad88321bf596bf01e0884fc