### PR TITLE
Add date picker for due date hotkey

### DIFF
--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -263,8 +263,8 @@ func TestDueDateHotkey(t *testing.T) {
 
 	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	m = mv.(Model)
-	for _, r := range "2024-12-31" {
-		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	for i := 0; i < 3; i++ {
+		mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
 		m = mv.(Model)
 	}
 	mv, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -275,7 +275,8 @@ func TestDueDateHotkey(t *testing.T) {
 		t.Fatalf("read due: %v", err)
 	}
 
-	if strings.TrimSpace(string(data)) != "1 modify due:2024-12-31" {
+	want := "1 modify due:" + time.Now().AddDate(0, 0, 3).Format("2006-01-02")
+	if strings.TrimSpace(string(data)) != want {
 		t.Fatalf("due not set: %q", data)
 	}
 }
@@ -470,7 +471,7 @@ func TestEscClosesHelp(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m = mv.(Model)
 	if !m.showHelp {
 		t.Fatalf("help not shown")


### PR DESCRIPTION
## Summary
- use a date picker instead of free text for the `d` hotkey
- adjust tests for the new picker and updated help hotkey

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855b9fa5b188321b69ed566425be2d1