### PR TITLE
Fix help hotkey overlap

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -274,7 +274,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		switch msg.String() {
-		case "h":
+		case "H":
 			m.showHelp = true
 			return m, nil
 		case "q", "esc":
@@ -443,7 +443,7 @@ func (m Model) View() string {
 			"p: set priority",
 			"/, ?: search",
 			"q: quit",
-			"h: help", // show help toggle line
+			"H: help", // show help toggle line
 		)
 	}
 	view := lipgloss.JoinVertical(lipgloss.Left,

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -471,7 +471,7 @@ func TestEscClosesHelp(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	mv, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}})
 	m = mv.(Model)
 	if !m.showHelp {
 		t.Fatalf("help not shown")


### PR DESCRIPTION
## Summary
- use `H` instead of `h` to open the help view so that `h` remains available for vim navigation
- update help text and the help hotkey test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855bc1e2290832190a339e01b6157ef