### PR TITLE
Display version and help hint in status bars

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"tasksamurai/internal"
 	atable "tasksamurai/internal/atable"
 	"tasksamurai/internal/task"
 )
@@ -479,7 +480,7 @@ func (m Model) View() string {
 }
 
 func (m Model) statusLine() string {
-	status := fmt.Sprintf("Total:%d InProgress:%d Due:%d", m.total, m.inProgress, m.due)
+	status := fmt.Sprintf("Total:%d InProgress:%d Due:%d | press H for help", m.total, m.inProgress, m.due)
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("229")).
 		Background(lipgloss.Color("57")).
@@ -493,11 +494,12 @@ func (m Model) topStatusLine() string {
 	if idx := m.tbl.ColumnCursor(); idx >= 0 && idx < len(cols) {
 		header = cols[idx].Title
 	}
+	line := fmt.Sprintf("Task Samurai %s | %s", internal.Version, header)
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("229")).
 		Background(lipgloss.Color("57")).
 		Width(m.tbl.Width()).
-		Render(header)
+		Render(line)
 }
 
 func taskToRow(t task.Task) atable.Row {

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,4 @@
 package internal
 
-const Version = "v0.1.0"
+// Version is the current version of Task Samurai.
+const Version = "0.0.1"


### PR DESCRIPTION
## Summary
- add Task Samurai version constant
- show Task Samurai version in the top status bar
- mention help shortcut in the bottom status bar

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855bcef7d70832188ee939f755b0b99