### PR TITLE
Implement disco mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Task Samurai invokes the `task` command to read and modify tasks. The tasks are 
 - `f`: change filter
 - `c`: random theme
 - `C`: reset theme
+- `x`: toggle disco mode
 - `space`: refresh tasks
 - `H`: toggle help
 - `q` or `esc`: close search/help or quit (press `q` when nothing is open)
@@ -79,3 +80,7 @@ go-task install
 ```
 
 The second method requires [go-task](https://taskfile.dev/) to be installed.
+
+### Flags
+
+- `--disco`: start Task Samurai in disco mode, changing the theme every time a task is modified.

--- a/cmd/tasksamurai/main.go
+++ b/cmd/tasksamurai/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	debugLog := flag.String("debug-log", "", "path to debug log file")
 	browserCmd := flag.String("browser-cmd", "firefox", "command used to open URLs")
+	disco := flag.Bool("disco", false, "enable disco mode")
 	flag.Parse()
 
 	if err := task.SetDebugLog(*debugLog); err != nil {
@@ -26,6 +27,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, "failed to load tasks:", err)
 		os.Exit(1)
 	}
+
+	m.SetDisco(*disco)
 
 	// Clear the screen before starting the TUI to avoid leaving any
 	// previous command line artefacts behind.

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -112,6 +112,7 @@ type Model struct {
 
 	theme        Theme
 	defaultTheme Theme
+	disco        bool
 }
 
 // editDoneMsg is emitted when the external editor process finishes.
@@ -147,6 +148,10 @@ func (m *Model) startBlink(id int, markDone bool) tea.Cmd {
 	}
 	if m.blinkRow == -1 {
 		return nil
+	}
+	if m.disco {
+		m.theme = RandomTheme()
+		m.applyTheme()
 	}
 	m.blinkOn = true
 	m.blinkCount = 0
@@ -764,6 +769,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.theme = m.defaultTheme
 			m.applyTheme()
 			return m, nil
+		case "x":
+			m.disco = !m.disco
+			return m, nil
 		case " ":
 			m.reload()
 			return m, nil
@@ -904,6 +912,7 @@ func (m Model) View() string {
 			"t: edit tags",
 			"c: random theme",
 			"C: reset theme",
+			"x: toggle disco mode",
 			"space: refresh tasks",
 			"/, ?: search",
 			"n/N: next/prev search match",
@@ -1404,6 +1413,11 @@ func (m *Model) applyTheme() {
 	m.tblStyles.Selected = m.tblStyles.Selected.Foreground(lipgloss.Color(m.theme.SelectedFG)).Background(lipgloss.Color(m.theme.SelectedBG))
 	m.tblStyles.Highlight = m.tblStyles.Highlight.Background(lipgloss.Color(m.theme.RowBG)).Foreground(lipgloss.Color(m.theme.RowFG))
 	m.tbl.SetStyles(m.tblStyles)
+}
+
+// SetDisco enables or disables disco mode.
+func (m *Model) SetDisco(d bool) {
+	m.disco = d
 }
 
 func centerLines(s string, width int) string {


### PR DESCRIPTION
## Summary
- add `--disco` flag to start Task Samurai in disco mode
- support toggling disco mode at runtime with new `x` hotkey
- randomize theme whenever a task changes while in disco mode
- document disco mode flag and hotkey

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b07d2c564832185245c0af5183bea